### PR TITLE
replace ngx.var.pid with ngx.worker.pid() to generate oid

### DIFF
--- a/lib/resty/moongoo/utils.lua
+++ b/lib/resty/moongoo/utils.lua
@@ -28,7 +28,7 @@ end
 local counter = 0
 
 local function generate_oid()
-  local pid = ngx and ngx.var.pid or nil
+  local pid = ngx and ngx.worker.pid() or nil
   if not pid then
     if hasposix then
       pid = posix.getpid("pid")


### PR DESCRIPTION
Use `ngx.worker.pid()` instead of `ngx.var.pid`:
1.  [`ngx.worker.pid()` is more efficient ](https://github.com/openresty/lua-nginx-module#ngxworkerpid), so that the library can be used in `init_worker_by_*` phase.
2. If patch this library with [resty-socket](https://github.com/thibaultcha/lua-resty-socket)，even can be used in `init_by_*` phase.