### PR TITLE
Fix authentication crash in mongodb3.6

### DIFF
--- a/lib/resty/moongoo/auth/scram.lua
+++ b/lib/resty/moongoo/auth/scram.lua
@@ -83,7 +83,7 @@ local function auth(db, username, password)
   if not r['done'] then
     r, err = db:_cmd("saslContinue", {
       conversationId = conversationId ;
-      payload =  cbson.binary("") ;
+      payload =  ngx.encode_base64("");
     })
 
     if not r then


### PR DESCRIPTION
try to use auth， and got openresty  (core dumped) 
mongodb version :3.6

carsh error message: 
src/bson/bson.c:812 bson_append_binary(): precondition failed: binary