### PR TITLE
Bugfixes of GridFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Finds the distinct values for a specified field, according to query.
 Returns array, containing unique filenames.
 
 #### remove
-`<cbson.uint>num, <string>err = gridfsobj:remove(<cbson.oid or string>id)`  
+`<cbson.uint>num, <string>err = gridfsobj:remove(<cbson.oid or self-chosen type>id)`  
 Removes file from GridFS.  
 Returns number of chunks removed.
 
@@ -386,7 +386,7 @@ E.g. for file with 3 versions: 0, 1, 2 = -3, -2, -1
 0 or -3 is oldest, while  -1 or 2 - newest.
 
 #### open
-`<gridfs.file>gridfsfile, <string>err = gridfsobj:open(<cbson.oid or string>id)`  
+`<gridfs.file>gridfsfile, <string>err = gridfsobj:open(<cbson.oid or self-chosen type>id)`  
 Opens GridFS file for reading.
 
 #### create
@@ -454,7 +454,7 @@ Returns full file contents.
 Writes data to GridFS file.
 
 #### close
-`<cbson.oid>id, <string>error = gridfsfile:close()`  
+`<cbson.oid or self-chosen type>id, <string>error = gridfsfile:close()`  
 Finalizes file by writing queued chunks and metadata.
 
 [Back to TOC](#table-of-contents)

--- a/lib/resty/moongoo/gridfs.lua
+++ b/lib/resty/moongoo/gridfs.lua
@@ -22,11 +22,11 @@ function _M.list(self)
 end
 
 function _M.remove(self, id)
-  local r,err = self._files:remove({_id = cbson.oid(id)})
+  local r,err = self._files:remove({_id = id})
   if not r then
     return nil, "Failed to remove file metadata: "..err
   end
-  r,err = self._chunks:remove({files_id = cbson.oid(id)});
+  r,err = self._chunks:remove({files_id = id})
   if not r then
     return nil, "Failed to remove file chunks: "..err
   end
@@ -45,7 +45,7 @@ function _M.find_version(self, name, version)
 end
 
 function _M.open(self, id)
-  return gfsfile.open(self, cbson.oid(id))
+  return gfsfile.open(self, id)
 end
 
 

--- a/lib/resty/moongoo/gridfs/file.lua
+++ b/lib/resty/moongoo/gridfs/file.lua
@@ -155,9 +155,11 @@ function _M.close(self)
   local file_md5 = res.md5
   -- insert metadata
   local ids, n = self._gridfs._files:insert(self:_metadata(file_md5))
-
   if not ids then
     return nil, n
+  end
+  if n < 1 then
+    return nil, "Duplicate file ID"
   end
   -- return metadata
   return ids[1]

--- a/lib/resty/moongoo/gridfs/file.lua
+++ b/lib/resty/moongoo/gridfs/file.lua
@@ -107,22 +107,23 @@ end
 
 function _M.write(self, data)
   if self._read_only then
-    return nil, "Can't write to read-only file"
+    return false, "Can't write to read-only file"
   end
 
   if self._closed then
-    return nil, "Can't write to closed file"
+    return false, "Can't write to closed file"
   end
 
   self._buffer = self._buffer .. data
   self._meta.length = self._meta.length + data:len()
 
   while self._buffer:len() >= self:chunk_size() do
-    local r, res = self:_chunk()
+    local r, err = self:_chunk()
     if not r then
-      return nil, err
+      return false, err
     end
   end
+  return true
 end
 
 function _M.close(self)

--- a/lib/resty/moongoo/gridfs/file.lua
+++ b/lib/resty/moongoo/gridfs/file.lua
@@ -202,8 +202,8 @@ end
 
 function _M._chunk(self)
   local chunk = self._buffer:sub(1,self:chunk_size())
-  if not chunk then
-    return false
+  if chunk:len() == 0 then
+    return true
   end
   self._buffer = self._buffer:sub(self:chunk_size()+1)
   local n = self._n


### PR DESCRIPTION
1. Fix self-chosen files id of GridFS

As the [document](https://docs.mongodb.com/manual/core/gridfs/#files._id) said, the files._id may not be ObjectId (_ObjectId changes monotonically, it does not benefit when sharding GridFS_). Like the example below, we can set it using a string or any other data types.

```lua
db:gridfs():create("test.lua", {_id = "foo"})
```

2. Make gridfs.file._chunk method return error when the file id duplicated on non-safe mode, so that we can handle the duplicate file id error as soon as possible